### PR TITLE
Added trim to reading file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function generateTSFiles(swaggerFileName, options) {
     let folder = path.normalize(options.modelFolder);
     // utils.removeFolder(folder);
 
-    let swagger = JSON.parse(fs.readFileSync(swaggerFileName, utils.ENCODING));
+    let swagger = JSON.parse(fs.readFileSync(swaggerFileName, utils.ENCODING).trim());
 
     modelGenerator.generateModelTSFiles(swagger, options);
     enumGenerator.generateEnumTSFile(swagger, options);


### PR DESCRIPTION
This is a bug where with the newest swagger adds some blank lines at the start of the json object. This is causing a error when trying to parse.