### PR TITLE
Add ability to generate only interfaces and enums, without classes and validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ npm install --save-dev swagger-ts-generator
 ## `gulp.config`
 Create a `gulp.config` file with the settings you want:
 
+* generateClasses (default: true)  - If this flag is set to false, the generator will output only interfaces and enums. It will not output classes and validators.
+
 ```javascript
 'use strict';
 
@@ -52,6 +54,7 @@ function config() {
                 folders.srcLanguagesFolder + 'nl.json',
                 folders.srcLanguagesFolder + 'en.json',
             ],
+            generateClasses: true,
             modelModuleName: 'webapi.models',
             enumModuleName: 'webapi.enums',
             enumRef: './enums',

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ function generateTSFiles(swaggerFileName, options) {
 
     let swagger = JSON.parse(fs.readFileSync(swaggerFileName, utils.ENCODING).trim());
 
+    if(!options.hasOwnProperty("generateClasses"))
+        options.generateClasses = true;
+
     modelGenerator.generateModelTSFiles(swagger, options);
     enumGenerator.generateEnumTSFile(swagger, options);
     if (options.enumI18NHtmlFile) {

--- a/lib/enumGenerator.js
+++ b/lib/enumGenerator.js
@@ -22,6 +22,7 @@ function generateEnumTSFile(swagger, options) {
     function generateTSEnums(enumTypeCollection, outputFileName, options) {
         let data = {
             moduleName: options.enumModuleName,
+            generateClasses: options.generateClasses,
             enumTypeCollection: enumTypeCollection
         }
         let template = utils.readAndCompileTemplateFile('generate-enum-ts.hbs');

--- a/lib/modelGenerator.js
+++ b/lib/modelGenerator.js
@@ -35,6 +35,9 @@ function generateModelTSFiles(swagger, options) {
 }
 
 function generateTSValidations(folder, options) {
+    if(!options.generateClasses)
+        return;
+
     let outputFileName = path.join(folder, VALDIDATORS_FILE_NAME);
     let data = {}
     let template = utils.readAndCompileTemplateFile('generate-validators-ts.hbs');
@@ -47,6 +50,9 @@ function generateTSValidations(folder, options) {
 }
 
 function generateTSBaseModel(folder, options) {
+    if(!options.generateClasses)
+        return;
+
     let outputFileName = path.join(folder, BASE_MODEL_FILE_NAME);
     let data = {}
     let template = utils.readAndCompileTemplateFile('generate-base-model-ts.hbs');
@@ -358,13 +364,13 @@ function removeGenericTType(type) {
     return type;
 }
 /**
- * NullableOrEmpty[System.Date] -> NullableOrEmpty<System.Date> 
+ * NullableOrEmpty[System.Date] -> NullableOrEmpty<System.Date>
  */
 function convertGenericTypeName(typeName) {
     return typeName.replace('[', '<').replace(']', '>');
 }
 /**
- * NullableOrEmpty<System.Date> -> NullableOrEmpty<T> 
+ * NullableOrEmpty<System.Date> -> NullableOrEmpty<T>
  */
 function convertGenericToGenericT(typeName) {
     return typeName.replace(/\<.*\>/, '<T>');
@@ -482,6 +488,7 @@ function getNamespaceGroups(typeCollection) {
 
 function generateTSModels(namespaceGroups, folder, options) {
     let data = {
+        generateClasses: options.generateClasses,
         moduleName: options.modelModuleName,
         enumModuleName: options.enumModuleName,
         enumRef: options.enumRef,
@@ -566,9 +573,11 @@ function generateBarrelFiles(namespaceGroups, folder, options) {
 
 function addRootFixedFileNames(fileNames, options) {
     let enumOutputFileName = path.normalize(options.enumTSFile.split('/').pop());
-    let validatorsOutputFileName = path.normalize(VALDIDATORS_FILE_NAME);
     fileNames.splice(0, 0, removeTsExtention(enumOutputFileName));
-    fileNames.splice(0, 0, removeTsExtention(validatorsOutputFileName));
+    if(options.generateClasses) {
+        let validatorsOutputFileName = path.normalize(VALDIDATORS_FILE_NAME);
+        fileNames.splice(0, 0, removeTsExtention(validatorsOutputFileName));
+    }
 }
 
 function removeTsExtention(fileName) {

--- a/templates/generate-enum-ts.hbs
+++ b/templates/generate-enum-ts.hbs
@@ -14,13 +14,15 @@ export enum {{type}} {
 }
 
 {{/enumTypeCollection}}
+
+{{#if generateClasses}}
 /**
  * bundle of all enums for databinding to options, radio-buttons etc.
  * usage in component:
  *   import { AllEnums, minValueValidator, maxValueValidator } from '../../models/webapi';
  *
  *   @Component({
- *       ... 
+ *       ...
  *   })
  *   export class xxxComponent implements OnInit {
  *       allEnums = AllEnums;
@@ -46,3 +48,4 @@ export class AllEnums {
     {{type}} = {{type}};
 {{/enumTypeCollection}}
 }
+{{/if}}

--- a/templates/generate-model-ts.hbs
+++ b/templates/generate-model-ts.hbs
@@ -3,10 +3,11 @@
  * Do not edit.
 */
 /* tslint:disable */
-
+{{#if generateClasses}}
 import { Validators, FormControl, FormGroup, FormArray, ValidatorFn } from '@angular/forms';
 import { minValueValidator, maxValueValidator, enumValidator } from '{{type.pathToRoot}}validators';
 import { BaseModel } from '{{type.pathToRoot}}base-model';
+{{/if}}
 
 {{#with type}}
     {{#if isSubType}}
@@ -21,11 +22,17 @@ import { {{importEnumType}} } from '{{../../enumRef}}';
     {{/if}}
 {{/properties}}
 
+{{#if generateClasses}}
 export interface I{{{typeName}}} {
+{{else}}
+export interface {{{typeName}}} {
+{{/if}}
 {{#properties}}
     {{name}}{{#unless validators.validation.required}}?{{/unless}}: {{{typeName}}};
 {{/properties}}
 }
+
+{{#if generateClasses}}
 
 export class {{{typeName}}}{{#if isSubType}} extends {{{baseType.typeName}}}{{/if}} extends BaseModel implements I{{{typeName}}} {
 {{#properties}}
@@ -35,9 +42,9 @@ export class {{{typeName}}}{{#if isSubType}} extends {{{baseType.typeName}}}{{/i
     {{name}}: {{{typeName}}};
 {{/properties}}
 
-    /** 
+    /**
      * constructor
-     * @param values Can be used to set a webapi response to this newly constructed model   
+     * @param values Can be used to set a webapi response to this newly constructed model
     */
     constructor(values?: any) {
         super();
@@ -55,7 +62,7 @@ export class {{{typeName}}}{{#if isSubType}} extends {{{baseType.typeName}}}{{/i
         }
     }
 
-    /** 
+    /**
      * set the values.
      * @param values Can be used to set a webapi response to this newly constructed model
     */
@@ -114,4 +121,6 @@ export class {{{typeName}}}{{#if isSubType}} extends {{{baseType.typeName}}}{{/i
         }
     }
 }
+
+{{/if}}
 {{/with}}


### PR DESCRIPTION
This is useful if you want to use this generator in a non angular environment, or you want to save on generated code that is bundled to the client.

If you don't change your build, it does nothing. But if you add generateClasses = false to your configuration it doesn't create the classes.