### PR TITLE
Bugfix for genarating interfaces with combined types

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jest": "^24.9.0",
         "request": "^2.88.0",
         "ts-jest": "^24.1.0",
-        "typescript": "^2.9.1",
+        "typescript": "^3.7.3",
         "util": "^0.12.1",
         "vinyl-source-stream": "^2.0.0",
         "yargs": "^14.2.0"

--- a/src/bootstrap/swagger.ts
+++ b/src/bootstrap/swagger.ts
@@ -1,4 +1,9 @@
-type Consumers = 'application/json' | 'text/json' | 'application/xml' | 'text/xml' | 'application/x-www-form-urlencoded';
+type Consumers =
+    | 'application/json'
+    | 'text/json'
+    | 'application/xml'
+    | 'text/xml'
+    | 'application/x-www-form-urlencoded';
 type Producers = 'application/json' | 'text/json' | 'application/xml' | 'text/xml';
 
 interface Schema {
@@ -30,7 +35,7 @@ export interface Swagger {
             post: SwaggerHttpEndpoint;
             put: SwaggerHttpEndpoint;
             delete: SwaggerHttpEndpoint;
-        }
+        };
     };
     definitions: SwaggerDefinitions;
 }
@@ -55,8 +60,8 @@ export interface SwaggerHttpEndpoint {
         [httpStatusCode: string]: {
             description: string;
             schema: Schema;
-        }
-    }
+        };
+    };
     deprecated: boolean;
 }
 
@@ -79,4 +84,7 @@ export interface SwaggerPropertyDefinition extends Schema {
     items?: SwaggerDefinition;
     readonly?: boolean;
     enum?: string[];
+    anyOf?: SwaggerDefinition[];
+    oneOf?: SwaggerDefinition[];
+    allOf?: SwaggerDefinition[];
 }

--- a/src/lib/model-generator.ts
+++ b/src/lib/model-generator.ts
@@ -530,6 +530,20 @@ function getPropertyType(item: SwaggerPropertyDefinition, name: string, options:
 
         return result;
     }
+    if (item.anyOf || item.oneOf) {
+        let combinedType = item.anyOf || item.oneOf;
+        if (!combinedType) return;
+        for (let propertyType of combinedType) {
+            let propType = getPropertyType(propertyType, name, options, isEnum);
+            if (!result.typeName.includes(propType.typeName)) {
+                if (result.typeName !== '') {
+                    result.typeName += ' | ';
+                }
+                result.typeName += propType.typeName;
+            }
+        }
+        return result;
+    }
 }
 
 function removeDefinitionsRef(value: string) {

--- a/templates/generate-model-ts.hbs
+++ b/templates/generate-model-ts.hbs
@@ -14,7 +14,7 @@ import { SubTypeFactory } from '{{type.pathToRoot}}{{subTypeFactoryFileName}}';
 
 {{#with type}}
     {{#if isSubType}}
-import { I{{baseType.typeName}}, {{baseType.typeName}} } from '{{baseImportFile}}';
+import { {{baseType.typeName}} } from '{{baseImportFile}}';
     {{/if}}
 {{#properties}}
     {{#if isUniqueImportType}}
@@ -28,7 +28,7 @@ import { {{importEnumType}} } from '{{../../enumRef}}';
 {{#if ../generateClasses}}
 export interface I{{{typeName}}} {
 {{else}}
-export interface {{{typeName}}} {
+export interface {{{typeName}}} {{#if hasSubTypeProperty}}extends {{{baseType.typeName}}}{{/if}} {
 {{/if}}
 {{#properties}}
     {{name}}{{#unless validators.validation.required}}?{{/unless}}: {{{typeName}}};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,10 @@
         "target": "es6",
         "module": "commonjs",
         "outDir": "./",
-        "sourceMap": false,
+        "sourceMap": true,
         "declaration": true,
-        // "typeRoots": []
-        "types": ["jest"]
+        "types": ["jest", "node"]
     },
-    "files": ["./node_modules/@types/node/index.d.ts"],
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4936,10 +4936,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^2.9.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.7.3:
+  version "3.7.4"
+  resolved "http://172.31.240.39:4873/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
I got a bug with generating the interface where one of the keys can be a `string` or an `object` from the following definition:
<details>
<summary>A definition from swagger schema</summary>
<pre><code>{
    "ReasonSchema": {
        "type": "object",
        "properties": {
            "value": {
                "anyOf": [
                    {
                        "type": "string"
                    },
                    {
                        "type": "object"
                    }
                ]
            }
        }
    }
}</code></pre>
</details>
<details>
<summary>Expected Typescript interface</summary>
<pre><code>export interface ReasonSchema  {
    value?: string | object;
}</code></pre>
</details>
Instead of generating the interface the parser crashed with the following error:
<details>
<pre><code>TypeError: Cannot read property 'typeName' of undefined
    at getTypePropertyDefinition (/home/alex/work/pew/tools/ifacegen/node_modules/swagger-ts-generator/lib/model-generator.js:211:92)
    at /home/alex/work/pew/tools/ifacegen/node_modules/swagger-ts-generator/lib/model-generator.js:187:24
    at /home/alex/work/pew/tools/ifacegen/node_modules/lodash/lodash.js:4905:15
    at baseForOwn (/home/alex/work/pew/tools/ifacegen/node_modules/lodash/lodash.js:2990:24)
    at /home/alex/work/pew/tools/ifacegen/node_modules/lodash/lodash.js:4874:18
    at Function.forEach (/home/alex/work/pew/tools/ifacegen/node_modules/lodash/lodash.js:9342:14)
    at fillTypeProperties (/home/alex/work/pew/tools/ifacegen/node_modules/swagger-ts-generator/lib/model-generator.js:186:14)
    at getTypeDefinition (/home/alex/work/pew/tools/ifacegen/node_modules/swagger-ts-generator/lib/model-generator.js:152:5)
    at /home/alex/work/pew/tools/ifacegen/node_modules/swagger-ts-generator/lib/model-generator.js:83:24
    at /home/alex/work/pew/tools/ifacegen/node_modules/lodash/lodash.js:4905:15</code></pre>
</details>

Looks like this case wasn't foreseen because there's no handling for `anyOf` and `oneOf` in the code.

So in this pull request I added this handling inside the `getPropertyType()` function.

I also updated Typescript to version 3.7 and fixed the template for `.model.ts`-files.
- fixed the subtype generating without extending the base type
- also removed the import of interface (that has `I` in its name). It still generated when `generateClasses` is set to `false` and wasn't used. It could cause build errors if `noUnusedLocals` parameter is used in tsconfig